### PR TITLE
fix(ci): Whitelist web.archive.org and discmaster.textfiles.com

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,4 +25,4 @@ jobs:
           ruby-version: 2.6.10
       - run: |
           gem install awesome_bot
-          awesome_bot readme.md --allow-redirect --white-list amazon.com/Tricks-Game-Programming-Gurus-Andre-Lamothe/dp/0672305070/
+          awesome_bot readme.md --allow-redirect --white-list amazon.com/Tricks-Game-Programming-Gurus-Andre-Lamothe/dp/0672305070/,discmaster.textfiles.com,web.archive.org


### PR DESCRIPTION
Relax CI rules for web.archive.org and discmaster.textfiles.com as they constantly break CI, even though these sites are accessible anyway.